### PR TITLE
#8 make executions unique

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .idea/
+build/
+__pycache__/
 venv/
 output/
 log/

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ pip install robotframework-webservice
 ```
 
 # Usage
+There are 2 types of endpoints: 
+1. Execution
+2. Reporting
+
+## Execution
+Endpoints that trigger execution of a robot task, for instance:
+
 Call robot task:
 
     http://localhost:5003/robotframework/run/mytask
@@ -22,7 +29,10 @@ Call robot task with variables:
 
     http://localhost:5003/robotframework/run/mytask?myVariable1=42&anotherVariable=Mustermann
 
-Response contains status and log report.
+Response contains a header field `x-request-id` that can be used to retrieve logs and reports of this execution asynchronously.
+
+## Reporting
+Endpoints that provide `log.html` and `report.html` for a specific task execution. You require the `x-request-id` from a previous response that triggered the execution.
 
 
 ## Start web service

--- a/RobotFrameworkService/main.py
+++ b/RobotFrameworkService/main.py
@@ -4,6 +4,7 @@ import uuid
 import contextvars
 from fastapi import FastAPI, Request
 from fastapi.staticfiles import StaticFiles
+from fastapi.responses import JSONResponse
 from uvicorn import Server
 from uvicorn.config import Config
 
@@ -24,7 +25,7 @@ async def request_middleware(request: Request, call_next):
     
     request.headers.__dict__["_list"].append(
         (
-            "request_id".encode(),
+            "request-id".encode(),
             request_id.encode()
         )
     )
@@ -33,18 +34,19 @@ async def request_middleware(request: Request, call_next):
 
     except Exception as ex:
         response = JSONResponse(content={"success": False}, status_code=500)
+        print(ex)
 
     finally:
         response.headers["X-Request-ID"] = request_id
         return response
 
 @app.get('/')
-def greetings(request: Request):
+async def greetings(request: Request):
     return 'web service for starting robot tasks'
 
 
 @app.get('/status/')
-def server_status():
+async def server_status():
     status = {'python version': sys.version,
               'platform': sys.platform,
               'arguments': sys.argv,

--- a/RobotFrameworkService/routers/robotframework.py
+++ b/RobotFrameworkService/routers/robotframework.py
@@ -86,7 +86,7 @@ async def show_report(task: str):
     return RedirectResponse(f'/logs/{task}/report.html')
 
 
-def _start_all_robot_tasks(id: int, variables: list = None) -> int:
+def _start_all_robot_tasks(id: str, variables: list = None) -> int:
     config = RFS_Config().cmd_args
     if variables is None:
         variables = []

--- a/RobotFrameworkService/routers/robotframework.py
+++ b/RobotFrameworkService/routers/robotframework.py
@@ -39,7 +39,8 @@ async def run_task(task, request: Request):
     """
     Run a given task.
     """
-    result: int = _start_specific_robot_task(task)
+    id = request.headers["request-id"]
+    result: int = _start_specific_robot_task(id, task)
     if result == 0:
         result_page = 'PASS'
     elif 250 >= result >= 1:
@@ -70,20 +71,20 @@ async def start_robot_task_and_show_report(task: str, arguments: Request):
     return RedirectResponse(f"/logs/{task}/report.html")
 
 
-@router.get('/show_log/{task}', response_class=HTMLResponse)
-async def show_log(task: str):
+@router.get('/show_log/{executionid}', response_class=HTMLResponse)
+async def show_log(executionid: str):
     """
     Show most recent log.html of given task
     """
-    return RedirectResponse(f'/logs/{task}/log.html')
+    return RedirectResponse(f'/logs/{executionid}/log.html')
 
 
-@router.get('/show_report/{task}', response_class=HTMLResponse)
-async def show_report(task: str):
+@router.get('/show_report/{executionid}', response_class=HTMLResponse)
+async def show_report(executionid: str):
     """
     Show most recent report.html of given task
     """
-    return RedirectResponse(f'/logs/{task}/report.html')
+    return RedirectResponse(f'/logs/{executionid}/report.html')
 
 
 def _start_all_robot_tasks(id: str, variables: list = None) -> int:

--- a/RobotFrameworkService/routers/robotframework.py
+++ b/RobotFrameworkService/routers/robotframework.py
@@ -9,12 +9,11 @@ import robot
 
 router = APIRouter(
     prefix="/robotframework",
-    tags=["robotframework"],
     responses={404: {"description": "Not found"}},
 )
 
 
-@router.get('/run/all')
+@router.get('/run/all', tags=["execution"])
 async def run(request: Request):
     """
     Run all task available.
@@ -34,7 +33,7 @@ async def run(request: Request):
     return Response(content=result_page, media_type="text/html", status_code=status_code)
 
 
-@router.get('/run/{task}')
+@router.get('/run/{task}', tags=["execution"])
 async def run_task(task, request: Request):
     """
     Run a given task.
@@ -51,7 +50,7 @@ async def run_task(task, request: Request):
     return Response(content=result_page, media_type="text/html")
 
 
-@router.get('/run_and_show/{task}', response_class=HTMLResponse)
+@router.get('/run_and_show/{task}', tags=["execution"], response_class=HTMLResponse)
 async def start_robot_task_and_show_log(task: str, arguments: Request):
     """
     Run a given task with variables and return log.html
@@ -61,7 +60,7 @@ async def start_robot_task_and_show_log(task: str, arguments: Request):
     return RedirectResponse(f"/logs/{task}/log.html")
 
 
-@router.get('/run_and_show_report/{task}', response_class=HTMLResponse)
+@router.get('/run_and_show_report/{task}', tags=["execution"], response_class=HTMLResponse)
 async def start_robot_task_and_show_report(task: str, arguments: Request):
     """
     Run a given task with variables and return report.html
@@ -71,7 +70,7 @@ async def start_robot_task_and_show_report(task: str, arguments: Request):
     return RedirectResponse(f"/logs/{task}/report.html")
 
 
-@router.get('/show_log/{executionid}', response_class=HTMLResponse)
+@router.get('/show_log/{executionid}', tags=["reporting"], response_class=HTMLResponse)
 async def show_log(executionid: str = Path(
     title="ID of a previous request",
     description="Insert here the value of a previous response header field 'x-request-id'"
@@ -83,7 +82,7 @@ async def show_log(executionid: str = Path(
     return RedirectResponse(f'/logs/{executionid}/log.html')
 
 
-@router.get('/show_report/{executionid}', response_class=HTMLResponse)
+@router.get('/show_report/{executionid}', tags=["reporting"], response_class=HTMLResponse)
 async def show_report(executionid: str = Path(
     title="ID of a previous request",
     description="Insert here the value of a previous response header field 'x-request-id'"

--- a/RobotFrameworkService/routers/robotframework.py
+++ b/RobotFrameworkService/routers/robotframework.py
@@ -15,11 +15,11 @@ router = APIRouter(
 
 
 @router.get('/run/all')
-async def run():
+async def run(request: Request):
     """
     Run all task available.
     """
-    id = time.time_ns()
+    id = request.headers["request-id"]
     result: int = _start_all_robot_tasks(id)
     if result == 0:
         result_page = 'PASS'
@@ -35,7 +35,7 @@ async def run():
 
 
 @router.get('/run/{task}')
-async def run_task(task):
+async def run_task(task, request: Request):
     """
     Run a given task.
     """
@@ -104,7 +104,7 @@ def _start_all_robot_tasks(id: int, variables: list = None) -> int:
     )
 
 
-def _start_specific_robot_task(task: str, variables: list = None) -> int:
+def _start_specific_robot_task(id: str, task: str, variables: list = None) -> int:
     config = RFS_Config().cmd_args
     if variables is None:
         variables = []
@@ -116,7 +116,7 @@ def _start_specific_robot_task(task: str, variables: list = None) -> int:
     return robot.run(
             config.taskfolder,
             task=task,
-            outputdir=f'logs/{task}',
+            outputdir=f'logs/{id}',
             variable=variables,
             variablefile=variablefiles,
             consolewidth=120

--- a/RobotFrameworkService/routers/robotframework.py
+++ b/RobotFrameworkService/routers/robotframework.py
@@ -1,6 +1,6 @@
 import time
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Path
 from fastapi.responses import HTMLResponse, Response, RedirectResponse
 from RobotFrameworkService.Config import Config as RFS_Config
 
@@ -72,17 +72,25 @@ async def start_robot_task_and_show_report(task: str, arguments: Request):
 
 
 @router.get('/show_log/{executionid}', response_class=HTMLResponse)
-async def show_log(executionid: str):
+async def show_log(executionid: str = Path(
+    title="ID of a previous request",
+    description="Insert here the value of a previous response header field 'x-request-id'"
+    )
+    ):
     """
-    Show most recent log.html of given task
+    Show most recent log.html from a given execution
     """
     return RedirectResponse(f'/logs/{executionid}/log.html')
 
 
 @router.get('/show_report/{executionid}', response_class=HTMLResponse)
-async def show_report(executionid: str):
+async def show_report(executionid: str = Path(
+    title="ID of a previous request",
+    description="Insert here the value of a previous response header field 'x-request-id'"
+    )
+    ):
     """
-    Show most recent report.html of given task
+    Show most recent report.html from a given execution
     """
     return RedirectResponse(f'/logs/{executionid}/report.html')
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -37,14 +37,16 @@ class EndpointTesttest_s(unittest.TestCase):
 
     def test_is_robotlog_available(self):
         with TestClient(app) as client:
-            client.get("/robotframework/run/anotherTask")
-            response = client.get("/robotframework/show_log/anotherTask")
-        self.assertEqual(200, response.status_code)
+            run_response = client.get("/robotframework/run/anotherTask")
+            execution_id = run_response.headers["x-request-id"]
+            logs_response = client.get(f'/robotframework/show_log/{execution_id}')
+        self.assertEqual(200, logs_response.status_code)
 
     def test_is_robotreport_available(self):
         with TestClient(app) as client:
-            client.get("/robotframework/run/anotherTask")
-            response = client.get("/robotframework/show_report/anotherTask")
-        self.assertEqual(200, response.status_code)
+            run_response = client.get("/robotframework/run/anotherTask")
+            execution_id = run_response.headers["x-request-id"]
+            report_response = client.get(f'/robotframework/show_report/{execution_id}')
+        self.assertEqual(200, report_response.status_code)
 
 


### PR DESCRIPTION
A Request-ID is now created with each request and returned in each response header at `x-request-id`.

When accessing an endpoint that triggers a test execution, the request-id is used to identify the execution. You can use the execution-id as task name in order to access reports after their execution.